### PR TITLE
Add NAT - use if want IP whitelisting

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -21,6 +21,11 @@ resource "aws_lambda_function" "kraken-dca-lambda" {
 
   timeout = 10
 
+  vpc_config {
+    subnet_ids         = [aws_subnet.private_subnet.id]
+    security_group_ids = [aws_default_security_group.default_security_group_for_vpc.id]
+  }
+
 }
 
 resource "aws_lambda_function" "kraken-withdraw-lambda" {
@@ -38,5 +43,10 @@ resource "aws_lambda_function" "kraken-withdraw-lambda" {
   role = aws_iam_role.iam-for-lambda.arn
 
   timeout = 10
+
+   vpc_config {
+    subnet_ids         = [aws_subnet.private_subnet.id]
+    security_group_ids = [aws_default_security_group.default_security_group_for_vpc.id]
+  }
 
 }

--- a/terraform/nat.tf
+++ b/terraform/nat.tf
@@ -1,0 +1,55 @@
+resource "aws_eip" "nat_eip" {
+  vpc        = true
+  depends_on = [aws_internet_gateway.ig]
+  instance   = aws_instance.ec2_nat_instance.id
+}
+resource "aws_instance" "ec2_nat_instance" {
+  ami           = "ami-0bbb886f29931c526"
+  instance_type = "t3.micro"
+  network_interface {
+    network_interface_id = aws_network_interface.nat_ec2_network_interface.id
+    device_index         = 0
+  }
+
+  tags = {
+    Name = "nat_instance"
+    Role = "nat"
+  }
+}
+resource "aws_network_interface" "nat_ec2_network_interface" {
+  subnet_id         = aws_subnet.public_subnet.id
+  security_groups   = [aws_security_group.security_group_to_use_for_nat.id]
+  source_dest_check = false
+}
+resource "aws_security_group" "security_group_to_use_for_nat" {
+  name   = "nat_instance_security_group"
+  vpc_id = aws_vpc.vpc.id
+
+  ingress = [
+    {
+      description      = "Allow all inbound traffic from Private IPs in VPC"
+      from_port        = 0
+      to_port          = 0
+      protocol         = "-1"
+      cidr_blocks      = [aws_vpc.vpc.cidr_block]
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = true
+    }
+  ]
+
+  egress = [
+    {
+      description      = "Allow all outbound traffic"
+      from_port        = 0
+      to_port          = 0
+      protocol         = "-1"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = true
+    }
+  ]
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,0 +1,91 @@
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.100.0.0/16"
+  tags = {
+    Name = "Kraken DCA VPC"
+  }
+}
+
+resource "aws_subnet" "private_subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = "10.100.0.0/24"
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "Kraken DCA private Subnet"
+  }
+}
+
+resource "aws_subnet" "public_subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = "10.100.1.0/24"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "Kraken DCA public Subnet"
+  }
+}
+
+resource "aws_internet_gateway" "ig" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "Kraken DCA internet gateway"
+  }
+}
+
+
+resource "aws_route_table" "private_subnet_route_table" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "Kraken-DCA-private-subnet-route-table"
+  }
+}
+
+resource "aws_route_table" "public_subnet_route_table" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "Kraken-DCA-public-subnet-route-table"
+  }
+}
+resource "aws_route" "public_internet_gateway" {
+  route_table_id         = aws_route_table.public_subnet_route_table.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.ig.id
+}
+resource "aws_route" "private_nat_instance" {
+  route_table_id         = aws_route_table.private_subnet_route_table.id
+  destination_cidr_block = "0.0.0.0/0"
+  network_interface_id   = aws_network_interface.nat_ec2_network_interface.id
+}
+
+resource "aws_route_table_association" "public_route_table_association" {
+  subnet_id      = aws_subnet.public_subnet.id
+  route_table_id = aws_route_table.public_subnet_route_table.id
+}
+resource "aws_route_table_association" "private_route_table_association" {
+  subnet_id      = aws_subnet.private_subnet.id
+  route_table_id = aws_route_table.private_subnet_route_table.id
+}
+
+resource "aws_default_security_group" "default_security_group_for_vpc" {
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    description = "Allow only inbound traffic that is a response to a request made previously"
+    protocol    = -1
+    self        = true
+    from_port   = 0
+    to_port     = 0
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "Kraken-DCA-default-security-group"
+  }
+}


### PR DESCRIPTION
Adding NAT with an elastic IP allows you to have a constant IP for traffic from Lambda. This can be used to add IP whitelisting for Kraken api keys